### PR TITLE
feat: Modificación del modelo para soportar Multi-Empresa

### DIFF
--- a/apps/fichaje-be/src/main/java/org/fichaje/controller/EmpresaController.java
+++ b/apps/fichaje-be/src/main/java/org/fichaje/controller/EmpresaController.java
@@ -65,4 +65,18 @@ public class EmpresaController
 		});
 	}
 
+	@Override
+	@Operation(summary = "Elimina una empresa")
+	@DeleteMapping("/{id}")
+	public ResponseEntity<?> delete(@PathVariable Long id) {
+		return service.findById(id).map(c -> {
+			service.delete(id);
+			// return ResponseEntity.ok(new Mensaje("Empresa eliminada"));
+			return ResponseEntity.status(HttpStatus.CREATED)
+					.body(new Mensaje("Empresa eliminada"));
+		}).orElseGet(() -> {
+			return ResponseEntity.notFound().build();
+		});
+	}
+
 }

--- a/apps/fichaje-be/src/main/java/org/fichaje/controller/EmpresaController.java
+++ b/apps/fichaje-be/src/main/java/org/fichaje/controller/EmpresaController.java
@@ -1,0 +1,68 @@
+package org.fichaje.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import org.fichaje.converter.EmpresaDtoConverter;
+import org.fichaje.dto.entity.EmpresaDto;
+import org.fichaje.dto.entity.Mensaje;
+import org.fichaje.provider.db.entity.Empresa;
+import org.fichaje.service.EmpresaService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestController
+@RequestMapping("/empresa")
+//@CrossOrigin(origins = "http://localhost:4200")
+public class EmpresaController
+		extends CommonController<Empresa, EmpresaService> {
+
+	@Autowired
+	EmpresaDtoConverter dtoConverter;
+
+	@Operation(summary = "Crea una nueva empresa")
+	@PostMapping("/create")
+	public ResponseEntity<?> newEmpresa(
+			@RequestBody EmpresaDto empresaDto) {
+		service.save(dtoConverter.transform(empresaDto));
+
+//		return ResponseEntity.created(null).build();
+		return ResponseEntity.status(HttpStatus.CREATED)
+				.body(new Mensaje("Empresa creada"));
+
+//		return ResponseEntity.status(HttpStatus.CREATED)
+//				.body(service.save(dtoConverter.transform(calendarioDto)));
+	}
+
+	@Operation(summary = "Devuelve una lista de DTO de empresas")
+	@GetMapping("/list/dto")
+	public ResponseEntity<List<EmpresaDto>> listDto() {
+		return ResponseEntity
+				.status(HttpStatus.OK)
+				.body(service.list().stream()
+						.map(c -> dtoConverter.inverseTransform(c))
+						.collect(Collectors.toList()));
+
+	}
+
+	@Operation(summary = "Edita una empresa")
+	@PutMapping("/{id}")
+	public ResponseEntity<?> editEmpresa(@RequestBody Empresa editar,
+			@PathVariable Long id) {
+
+		return service.findById(id).map(c -> {
+			c.setId(editar.getId());
+			c.setNombre(editar.getNombre());
+			c.setCif(editar.getCif());
+			c.setActiva(editar.isActiva());
+
+			return ResponseEntity.ok(service.save(c));
+		}).orElseGet(() -> {
+			return ResponseEntity.notFound().build();
+		});
+	}
+
+}

--- a/apps/fichaje-be/src/main/java/org/fichaje/converter/EmpresaDtoConverter.java
+++ b/apps/fichaje-be/src/main/java/org/fichaje/converter/EmpresaDtoConverter.java
@@ -1,0 +1,34 @@
+package org.fichaje.converter;
+
+import org.fichaje.dto.entity.EmpresaDto;
+import org.fichaje.provider.db.entity.Empresa;
+import org.springframework.stereotype.Component;
+
+@Component
+public class EmpresaDtoConverter {
+
+//	@Autowired
+//	private DiaDtoToDia service;
+
+	public Empresa transform(EmpresaDto dto) {
+		Empresa e = new Empresa();
+		e.setNombre(dto.getNombre());
+		e.setCif(dto.getCif());
+		e.setActiva(dto.isActiva());
+//		c.setDias(
+//				dto.getDias().stream()
+//						.map(diaDto -> service.transform(diaDto))
+//						.collect(Collectors.toList()));
+		return e;
+	}
+
+	public EmpresaDto inverseTransform(Empresa e) {
+		EmpresaDto dto = new EmpresaDto();
+		dto.setId(e.getId());
+		dto.setNombre(e.getNombre());
+		dto.setCif(e.getCif());
+		dto.setActiva(e.isActiva());
+		return dto;
+	}
+
+}

--- a/apps/fichaje-be/src/main/java/org/fichaje/dto/entity/EmpresaDto.java
+++ b/apps/fichaje-be/src/main/java/org/fichaje/dto/entity/EmpresaDto.java
@@ -1,0 +1,20 @@
+package org.fichaje.dto.entity;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class EmpresaDto {
+
+	private long id;
+	private String nombre;
+	private String cif;
+	private boolean activa;
+
+}

--- a/apps/fichaje-be/src/main/java/org/fichaje/dto/entity/EmpresaDto.java
+++ b/apps/fichaje-be/src/main/java/org/fichaje/dto/entity/EmpresaDto.java
@@ -12,7 +12,7 @@ import java.util.List;
 @AllArgsConstructor
 public class EmpresaDto {
 
-	private long id;
+	private Long id;
 	private String nombre;
 	private String cif;
 	private boolean activa;

--- a/apps/fichaje-be/src/main/java/org/fichaje/provider/db/entity/ApiKey.java
+++ b/apps/fichaje-be/src/main/java/org/fichaje/provider/db/entity/ApiKey.java
@@ -63,6 +63,11 @@ public class ApiKey {
     @Column(length = 100)
     private String createdBy; // Usuario que creó la API Key
 
+    @NotNull
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "empresa_id", nullable = false)
+    private Empresa empresa; // Empresa asociado a la API Key
+
     /**
      * Verifica si la API Key está activa y no ha expirado
      */

--- a/apps/fichaje-be/src/main/java/org/fichaje/provider/db/entity/Calendario.java
+++ b/apps/fichaje-be/src/main/java/org/fichaje/provider/db/entity/Calendario.java
@@ -49,4 +49,9 @@ public class Calendario {
 	@JsonIgnoreProperties(value = { "calendario" })
 	@OneToMany(mappedBy = "calendario", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<DiaLaborable> dias;
+
+	@JsonIgnoreProperties(value = { "calendarios" })
+	@ManyToOne
+	@JoinColumn(name = "empresa_id")
+	private Empresa empresa;
 }

--- a/apps/fichaje-be/src/main/java/org/fichaje/provider/db/entity/Calendario.java
+++ b/apps/fichaje-be/src/main/java/org/fichaje/provider/db/entity/Calendario.java
@@ -2,16 +2,7 @@ package org.fichaje.provider.db.entity;
 
 import java.util.List;
 
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.Table;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.*;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import jakarta.validation.constraints.NotNull;
@@ -28,7 +19,7 @@ import lombok.NoArgsConstructor;
 public class Calendario {
 
 	@Id
-	@GeneratedValue()
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
 	@NotNull

--- a/apps/fichaje-be/src/main/java/org/fichaje/provider/db/entity/Calendario.java
+++ b/apps/fichaje-be/src/main/java/org/fichaje/provider/db/entity/Calendario.java
@@ -10,6 +10,8 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import jakarta.validation.constraints.NotNull;

--- a/apps/fichaje-be/src/main/java/org/fichaje/provider/db/entity/DiaLaborable.java
+++ b/apps/fichaje-be/src/main/java/org/fichaje/provider/db/entity/DiaLaborable.java
@@ -3,14 +3,7 @@ package org.fichaje.provider.db.entity;
 import java.time.LocalDate;
 import java.time.LocalTime;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -28,7 +21,7 @@ import lombok.NoArgsConstructor;
 public class DiaLaborable {
 
 	@Id
-	@GeneratedValue()
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
 //	@NotNull

--- a/apps/fichaje-be/src/main/java/org/fichaje/provider/db/entity/Empresa.java
+++ b/apps/fichaje-be/src/main/java/org/fichaje/provider/db/entity/Empresa.java
@@ -1,0 +1,43 @@
+package org.fichaje.provider.db.entity;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.sun.istack.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "empresa")
+public class Empresa {
+
+	@Id
+	@GeneratedValue()
+	private Long id;
+
+	@NotNull
+	@Column()
+	private String nombre;
+
+	@NotNull
+	@Column(unique = true)
+	private String cif;
+
+	@Column(columnDefinition = "boolean default false")
+	private boolean activa;
+
+	@JsonIgnoreProperties(value = { "empresa" })
+	@OneToMany(mappedBy = "empresa", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<Calendario> calendarios;
+
+	@JsonIgnore
+	@NotNull
+	@ManyToMany(mappedBy = "empresas")
+	private List<Usuario> usuarios;
+}

--- a/apps/fichaje-be/src/main/java/org/fichaje/provider/db/entity/Empresa.java
+++ b/apps/fichaje-be/src/main/java/org/fichaje/provider/db/entity/Empresa.java
@@ -2,12 +2,12 @@ package org.fichaje.provider.db.entity;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.sun.istack.NotNull;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 import java.util.List;
 
 @Data

--- a/apps/fichaje-be/src/main/java/org/fichaje/provider/db/entity/Empresa.java
+++ b/apps/fichaje-be/src/main/java/org/fichaje/provider/db/entity/Empresa.java
@@ -8,6 +8,8 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import jakarta.persistence.*;
+
+import java.util.ArrayList;
 import java.util.List;
 
 @Data
@@ -37,7 +39,6 @@ public class Empresa {
 	private List<Calendario> calendarios;
 
 	@JsonIgnore
-	@NotNull
 	@ManyToMany(mappedBy = "empresas")
-	private List<Usuario> usuarios;
+	private List<Usuario> usuarios = new ArrayList<>();
 }

--- a/apps/fichaje-be/src/main/java/org/fichaje/provider/db/entity/Empresa.java
+++ b/apps/fichaje-be/src/main/java/org/fichaje/provider/db/entity/Empresa.java
@@ -18,7 +18,7 @@ import java.util.List;
 public class Empresa {
 
 	@Id
-	@GeneratedValue()
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
 	@NotNull

--- a/apps/fichaje-be/src/main/java/org/fichaje/provider/db/entity/Fichaje.java
+++ b/apps/fichaje-be/src/main/java/org/fichaje/provider/db/entity/Fichaje.java
@@ -57,4 +57,8 @@ public class Fichaje {
 
 	@NotNull
 	private String origen;
+
+	@ManyToOne(fetch = FetchType.EAGER)
+	@JoinColumn(name = "empresa_id", nullable = false)
+	private Empresa empresa;
 }

--- a/apps/fichaje-be/src/main/java/org/fichaje/provider/db/entity/Fichaje.java
+++ b/apps/fichaje-be/src/main/java/org/fichaje/provider/db/entity/Fichaje.java
@@ -3,13 +3,7 @@ package org.fichaje.provider.db.entity;
 import java.time.LocalDate;
 import java.time.LocalTime;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
-import jakarta.persistence.FetchType;
+import jakarta.persistence.*;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -29,7 +23,7 @@ import lombok.NoArgsConstructor;
 public class Fichaje {
 
 	@Id
-	@GeneratedValue
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
 //	@NotNull

--- a/apps/fichaje-be/src/main/java/org/fichaje/provider/db/entity/Fichaje.java
+++ b/apps/fichaje-be/src/main/java/org/fichaje/provider/db/entity/Fichaje.java
@@ -9,6 +9,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.FetchType;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/apps/fichaje-be/src/main/java/org/fichaje/provider/db/entity/Incidencia.java
+++ b/apps/fichaje-be/src/main/java/org/fichaje/provider/db/entity/Incidencia.java
@@ -2,14 +2,7 @@ package org.fichaje.provider.db.entity;
 
 import java.time.LocalDate;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
-import jakarta.persistence.FetchType;
+import jakarta.persistence.*;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -28,7 +21,7 @@ import lombok.NoArgsConstructor;
 public class Incidencia {
 
 	@Id
-	@GeneratedValue
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
 	@JsonIgnore

--- a/apps/fichaje-be/src/main/java/org/fichaje/provider/db/entity/Incidencia.java
+++ b/apps/fichaje-be/src/main/java/org/fichaje/provider/db/entity/Incidencia.java
@@ -9,6 +9,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.FetchType;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnore;

--- a/apps/fichaje-be/src/main/java/org/fichaje/provider/db/entity/Incidencia.java
+++ b/apps/fichaje-be/src/main/java/org/fichaje/provider/db/entity/Incidencia.java
@@ -56,4 +56,8 @@ public class Incidencia {
 	@JoinColumn(name = "usuario_id")
 	private Usuario usuario;
 
+	@ManyToOne(fetch = FetchType.EAGER)
+	@JoinColumn(name = "empresa_id", nullable = false)
+	private Empresa empresa;
+
 }

--- a/apps/fichaje-be/src/main/java/org/fichaje/provider/db/entity/Permiso.java
+++ b/apps/fichaje-be/src/main/java/org/fichaje/provider/db/entity/Permiso.java
@@ -10,6 +10,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.FetchType;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/apps/fichaje-be/src/main/java/org/fichaje/provider/db/entity/Permiso.java
+++ b/apps/fichaje-be/src/main/java/org/fichaje/provider/db/entity/Permiso.java
@@ -3,14 +3,7 @@ package org.fichaje.provider.db.entity;
 import java.time.LocalDate;
 import java.time.LocalTime;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
-import jakarta.persistence.FetchType;
+import jakarta.persistence.*;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -29,7 +22,7 @@ import lombok.NoArgsConstructor;
 public class Permiso {
 
 	@Id
-	@GeneratedValue
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
 //	@NotNull

--- a/apps/fichaje-be/src/main/java/org/fichaje/provider/db/entity/Permiso.java
+++ b/apps/fichaje-be/src/main/java/org/fichaje/provider/db/entity/Permiso.java
@@ -68,4 +68,8 @@ public class Permiso {
 	@ManyToOne
 	@JoinColumn(name = "usuario_id")
 	private Usuario usuario;
+
+	@ManyToOne(fetch = FetchType.EAGER)
+	@JoinColumn(name = "empresa_id", nullable = false)
+	private Empresa empresa;
 }

--- a/apps/fichaje-be/src/main/java/org/fichaje/provider/db/entity/Rol.java
+++ b/apps/fichaje-be/src/main/java/org/fichaje/provider/db/entity/Rol.java
@@ -1,11 +1,6 @@
 package org.fichaje.provider.db.entity;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 
 import org.fichaje.config.security.enums.RolNombre;
 import jakarta.validation.constraints.NotNull;
@@ -21,7 +16,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "roles")
 public class Rol {
 	@Id
-	@GeneratedValue
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 	@NotNull
 	@Enumerated(EnumType.STRING)

--- a/apps/fichaje-be/src/main/java/org/fichaje/provider/db/entity/Usuario.java
+++ b/apps/fichaje-be/src/main/java/org/fichaje/provider/db/entity/Usuario.java
@@ -2,17 +2,7 @@ package org.fichaje.provider.db.entity;
 
 import java.util.List;
 
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.JoinTable;
-import jakarta.persistence.ManyToMany;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -31,7 +21,7 @@ import lombok.NoArgsConstructor;
 public class Usuario {
 
 	@Id
-	@GeneratedValue
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
 	@NotNull

--- a/apps/fichaje-be/src/main/java/org/fichaje/provider/db/entity/Usuario.java
+++ b/apps/fichaje-be/src/main/java/org/fichaje/provider/db/entity/Usuario.java
@@ -105,6 +105,12 @@ public class Usuario {
 	@OneToMany(mappedBy = "usuario", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<Vacaciones> vacaciones;
 
+	@JsonIgnore
+	@NotNull
+	@ManyToMany(fetch = FetchType.EAGER)
+	@JoinTable(name = "usuario_empresa", joinColumns = @JoinColumn(name = "usuario_id"), inverseJoinColumns = @JoinColumn(name = "empresa_id"))
+	private List<Empresa> empresas;
+
 //	@ManyToOne
 //	@JoinColumn(name = "calendario_id")
 //	private Calendario calendario;

--- a/apps/fichaje-be/src/main/java/org/fichaje/provider/db/entity/Usuario.java
+++ b/apps/fichaje-be/src/main/java/org/fichaje/provider/db/entity/Usuario.java
@@ -67,7 +67,6 @@ public class Usuario {
 	private Boolean admin;
 
 	@JsonIgnore
-	@NotNull
 	@ManyToMany(fetch = FetchType.EAGER)
 	@JoinTable(name = "usuario_rol", joinColumns = @JoinColumn(name = "usuario_id"), inverseJoinColumns = @JoinColumn(name = "rol_id"))
 //	private Set<Rol> roles = new HashSet<>();
@@ -96,7 +95,6 @@ public class Usuario {
 	private List<Vacaciones> vacaciones;
 
 	@JsonIgnore
-	@NotNull
 	@ManyToMany(fetch = FetchType.EAGER)
 	@JoinTable(name = "usuario_empresa", joinColumns = @JoinColumn(name = "usuario_id"), inverseJoinColumns = @JoinColumn(name = "empresa_id"))
 	private List<Empresa> empresas;

--- a/apps/fichaje-be/src/main/java/org/fichaje/provider/db/entity/Vacaciones.java
+++ b/apps/fichaje-be/src/main/java/org/fichaje/provider/db/entity/Vacaciones.java
@@ -59,4 +59,8 @@ public class Vacaciones {
 	@ManyToOne
 	@JoinColumn(name = "usuario_id")
 	private Usuario usuario;
+
+	@ManyToOne(fetch = FetchType.EAGER)
+	@JoinColumn(name = "empresa_id", nullable = false)
+	private Empresa empresa;
 }

--- a/apps/fichaje-be/src/main/java/org/fichaje/provider/db/entity/Vacaciones.java
+++ b/apps/fichaje-be/src/main/java/org/fichaje/provider/db/entity/Vacaciones.java
@@ -8,6 +8,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.FetchType;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/apps/fichaje-be/src/main/java/org/fichaje/provider/db/entity/Vacaciones.java
+++ b/apps/fichaje-be/src/main/java/org/fichaje/provider/db/entity/Vacaciones.java
@@ -2,13 +2,7 @@ package org.fichaje.provider.db.entity;
 
 import java.time.LocalDate;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.FetchType;
+import jakarta.persistence.*;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -26,7 +20,7 @@ import lombok.NoArgsConstructor;
 public class Vacaciones {
 
 	@Id
-	@GeneratedValue
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
 //	@NotNull

--- a/apps/fichaje-be/src/main/java/org/fichaje/provider/db/repository/EmpresaRepository.java
+++ b/apps/fichaje-be/src/main/java/org/fichaje/provider/db/repository/EmpresaRepository.java
@@ -1,0 +1,17 @@
+package org.fichaje.provider.db.repository;
+
+import org.fichaje.provider.db.entity.Empresa;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface EmpresaRepository
+		extends JpaRepository<Empresa, Long>, JpaSpecificationExecutor<Empresa> {
+
+	Optional<Empresa> findByCif(String cif);
+
+	Optional<Empresa> findByActiva(Boolean activa);
+}

--- a/apps/fichaje-be/src/main/java/org/fichaje/service/EmpresaService.java
+++ b/apps/fichaje-be/src/main/java/org/fichaje/service/EmpresaService.java
@@ -1,0 +1,23 @@
+package org.fichaje.service;
+
+import org.fichaje.provider.db.entity.Empresa;
+import org.fichaje.provider.db.repository.EmpresaRepository;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+import java.util.Optional;
+
+@Service
+@Transactional
+public class EmpresaService
+		extends CommonServiceImpl<Empresa, EmpresaRepository> {
+
+	public Optional<Empresa> findByCif(String cif) {
+		return repository.findByCif(cif);
+	}
+
+	public Optional<Empresa> findByActiva(Boolean activa) {
+		return repository.findByActiva(activa);
+	}
+
+}

--- a/apps/fichaje-be/src/main/java/org/fichaje/service/EmpresaService.java
+++ b/apps/fichaje-be/src/main/java/org/fichaje/service/EmpresaService.java
@@ -4,7 +4,7 @@ import org.fichaje.provider.db.entity.Empresa;
 import org.fichaje.provider.db.repository.EmpresaRepository;
 import org.springframework.stereotype.Service;
 
-import javax.transaction.Transactional;
+import jakarta.transaction.Transactional;
 import java.util.Optional;
 
 @Service

--- a/apps/fichaje-be/src/main/resources/application-dev.properties
+++ b/apps/fichaje-be/src/main/resources/application-dev.properties
@@ -6,6 +6,8 @@ spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
+# Forzar InnoDB como motor de almacenamiento (MyISAM no soporta FK ni transacciones)
+spring.jpa.properties.hibernate.dialect.storage_engine=innodb
 
 # Mail (MailHog)
 spring.mail.host=localhost

--- a/apps/fichaje-be/src/main/resources/application-dev.properties
+++ b/apps/fichaje-be/src/main/resources/application-dev.properties
@@ -6,8 +6,6 @@ spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
-# Forzar InnoDB como motor de almacenamiento (MyISAM no soporta FK ni transacciones)
-spring.jpa.properties.hibernate.dialect.storage_engine=innodb
 
 # Mail (MailHog)
 spring.mail.host=localhost

--- a/apps/fichaje-be/src/main/resources/db/changelog/changes/20260305-multi_empresa_schema.xml
+++ b/apps/fichaje-be/src/main/resources/db/changelog/changes/20260305-multi_empresa_schema.xml
@@ -1,0 +1,106 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:pro="http://www.liquibase.org/xml/ns/pro" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/pro http://www.liquibase.org/xml/ns/pro/liquibase-pro-4.1.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
+    <changeSet author="Daviid" id="20260305-multi-empresa-1">
+        <createTable tableName="empresa">
+            <column autoIncrement="true" name="id" type="BIGINT">
+                <constraints nullable="false" primaryKey="true"/>
+            </column>
+            <column name="nombre" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="cif" type="VARCHAR(20)">
+                <constraints nullable="false" unique="true" uniqueConstraintName="uk_empresa_cif"/>
+            </column>
+            <column name="activa" type="TINYINT" defaultValueNumeric="1">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+        <rollback>
+            <dropTable tableName="empresa"/>
+        </rollback>
+    </changeSet>
+
+    <changeSet author="Daviid" id="20260305-multi-empresa-2">
+        <createTable tableName="usuario_empresa">
+            <column name="empresa_id" type="BIGINT">
+                <constraints nullable="false" primaryKey="true"/>
+            </column>
+            <column name="usuario_id" type="BIGINT">
+                <constraints nullable="false" primaryKey="true"/>
+            </column>
+        </createTable>
+        <rollback>
+            <dropTable tableName="usuario_empresa"/>
+        </rollback>
+    </changeSet>
+
+    <changeSet author="Daviid" id="20260305-multi-empresa-3">
+        <addColumn tableName="calendarios">
+            <column name="empresa_id" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+        <rollback>
+            <dropColumn tableName="calendarios" columnName="empresa_id"/>
+        </rollback>
+    </changeSet>
+
+    <changeSet author="Daviid" id="20260305-multi-empresa-4">
+        <addColumn tableName="api_keys">
+            <column name="empresa_id" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+        <rollback>
+            <dropColumn tableName="api_keys" columnName="empresa_id"/>
+        </rollback>
+    </changeSet>
+
+    <changeSet author="Daviid" id="20260305-multi-empresa-5">
+        <addForeignKeyConstraint
+                baseTableName="usuario_empresa"
+                baseColumnNames="empresa_id"
+                constraintName="fk_usuario_empresa"
+                referencedTableName="empresa"
+                referencedColumnNames="id"/>
+        <rollback>
+            <dropForeignKeyConstraint baseTableName="usuario_empresa" constraintName="fk_usuario_empresa"/>
+        </rollback>
+    </changeSet>
+
+    <changeSet author="Daviid" id="20260305-multi-empresa-6">
+        <addForeignKeyConstraint
+                baseTableName="usuario_empresa"
+                baseColumnNames="usuario_id"
+                constraintName="fk_usuario_empresa_usuario"
+                referencedTableName="usuarios"
+                referencedColumnNames="id"/>
+        <rollback>
+            <dropForeignKeyConstraint baseTableName="usuario_empresa" constraintName="fk_usuario_empresa_usuario"/>
+        </rollback>
+    </changeSet>
+
+    <changeSet author="Daviid" id="20260305-multi-empresa-7">
+        <addForeignKeyConstraint
+                baseTableName="calendarios"
+                baseColumnNames="empresa_id"
+                constraintName="fk_calendarios_empresa"
+                referencedTableName="empresa"
+                referencedColumnNames="id"/>
+        <rollback>
+            <dropForeignKeyConstraint baseTableName="calendarios" constraintName="fk_calendarios_empresa"/>
+        </rollback>
+    </changeSet>
+
+    <changeSet author="Daviid" id="20260305-multi-empresa-8">
+        <addForeignKeyConstraint
+                baseTableName="api_keys"
+                baseColumnNames="empresa_id"
+                constraintName="fk_apikey_empresa"
+                referencedTableName="empresa"
+                referencedColumnNames="id"/>
+        <rollback>
+            <dropForeignKeyConstraint baseTableName="api_keys" constraintName="fk_apikey_empresa"/>
+        </rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/apps/fichaje-be/src/main/resources/db/changelog/changes/20260305-multi_empresa_schema.xml
+++ b/apps/fichaje-be/src/main/resources/db/changelog/changes/20260305-multi_empresa_schema.xml
@@ -103,4 +103,96 @@
             <dropForeignKeyConstraint baseTableName="api_keys" constraintName="fk_apikey_empresa"/>
         </rollback>
     </changeSet>
+
+    <changeSet author="Daviid" id="20260305-multi-empresa-9">
+        <addColumn tableName="fichajes">
+            <column name="empresa_id" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+        <rollback>
+            <dropColumn tableName="fichajes" columnName="empresa_id"/>
+        </rollback>
+    </changeSet>
+
+    <changeSet author="Daviid" id="20260305-multi-empresa-10">
+        <addForeignKeyConstraint
+                baseTableName="fichajes"
+                baseColumnNames="empresa_id"
+                constraintName="fk_fichajes_empresa"
+                referencedTableName="empresa"
+                referencedColumnNames="id"/>
+        <rollback>
+            <dropForeignKeyConstraint baseTableName="fichajes" constraintName="fk_fichajes_empresa"/>
+        </rollback>
+    </changeSet>
+
+    <changeSet author="Daviid" id="20260305-multi-empresa-11">
+        <addColumn tableName="vacaciones">
+            <column name="empresa_id" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+        <rollback>
+            <dropColumn tableName="vacaciones" columnName="empresa_id"/>
+        </rollback>
+    </changeSet>
+
+    <changeSet author="Daviid" id="20260305-multi-empresa-12">
+        <addForeignKeyConstraint
+                baseTableName="vacaciones"
+                baseColumnNames="empresa_id"
+                constraintName="fk_vacaciones_empresa"
+                referencedTableName="empresa"
+                referencedColumnNames="id"/>
+        <rollback>
+            <dropForeignKeyConstraint baseTableName="vacaciones" constraintName="fk_vacaciones_empresa"/>
+        </rollback>
+    </changeSet>
+
+    <changeSet author="Daviid" id="20260305-multi-empresa-13">
+        <addColumn tableName="incidencias">
+            <column name="empresa_id" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+        <rollback>
+            <dropColumn tableName="incidencias" columnName="empresa_id"/>
+        </rollback>
+    </changeSet>
+
+    <changeSet author="Daviid" id="20260305-multi-empresa-14">
+        <addForeignKeyConstraint
+                baseTableName="incidencias"
+                baseColumnNames="empresa_id"
+                constraintName="fk_incidencias_empresa"
+                referencedTableName="empresa"
+                referencedColumnNames="id"/>
+        <rollback>
+            <dropForeignKeyConstraint baseTableName="incidencias" constraintName="fk_incidencias_empresa"/>
+        </rollback>
+    </changeSet>
+
+    <changeSet author="Daviid" id="20260305-multi-empresa-15">
+        <addColumn tableName="permisos">
+            <column name="empresa_id" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+        <rollback>
+            <dropColumn tableName="permisos" columnName="empresa_id"/>
+        </rollback>
+    </changeSet>
+
+    <changeSet author="Daviid" id="20260305-multi-empresa-16">
+        <addForeignKeyConstraint
+                baseTableName="permisos"
+                baseColumnNames="empresa_id"
+                constraintName="fk_permisos_empresa"
+                referencedTableName="empresa"
+                referencedColumnNames="id"/>
+        <rollback>
+            <dropForeignKeyConstraint baseTableName="permisos" constraintName="fk_permisos_empresa"/>
+        </rollback>
+    </changeSet>
 </databaseChangeLog>

--- a/apps/fichaje-be/src/main/resources/db/changelog/master.xml
+++ b/apps/fichaje-be/src/main/resources/db/changelog/master.xml
@@ -6,5 +6,6 @@
         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.20.xsd">
 
     <include file="/db/changelog/changes/20260303-initial-schema.xml"/>
+    <include file="/db/changelog/changes/20260305-multi_empresa_schema.xml"/>
 
 </databaseChangeLog>


### PR DESCRIPTION
## Descripción

Modificación del modelo de BBDD para soportar la funcionalidad de ser multi-empresa.

## Cambios realizados

- Creación de las nuevas entidades JPA para Empresas y establecimiento de sus relaciones con el modelo de datos existente.
- Implementación de la capa de presentación (Controllers) y lógica de negocio (Services) para la gestión de empresas.
- Creación de DTOs y DtoConverters para aislar el modelo de base de datos de las respuestas y peticiones de la API.
- Modificación de la estrategia de generación de claves primarias a GenerationType.IDENTITY en el modelo para delegar la creación del ID a la base de datos.

## Issue relacionado

Issue #47 